### PR TITLE
feat: apply monochrome button styles

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,44 +1,16 @@
-import Link from "next/link";
+import SiteHeader from "@/components/SiteHeader";
 
 export default function About() {
   return (
     <div className="min-h-screen bg-gray-50">
-      {/* Header */}
-      <header className="bg-white shadow-sm">
-        <nav className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between h-16">
-            <div className="flex items-center">
-              <Link href="/" className="text-xl font-bold text-gray-900">
-                ポートフォリオブログ
-              </Link>
-            </div>
-            <div className="flex items-center space-x-8">
-              <Link href="/" className="text-gray-700 hover:text-gray-900">
-                ホーム
-              </Link>
-              <Link href="/about" className="text-blue-600 font-semibold">
-                自己紹介
-              </Link>
-              <Link href="/blog" className="text-gray-700 hover:text-gray-900">
-                ブログ
-              </Link>
-              <Link
-                href="/contact"
-                className="text-gray-700 hover:text-gray-900"
-              >
-                お問い合わせ
-              </Link>
-            </div>
-          </div>
-        </nav>
-      </header>
+      <SiteHeader />
 
       {/* Hero Section */}
-      <section className="bg-white py-20">
+      <section className="py-20">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center">
-            <h1 className="text-4xl font-bold text-gray-900 mb-6">自己紹介</h1>
-            <p className="text-xl text-gray-600 mb-8">
+            <h1 className="text-4xl font-bold text-black mb-6">自己紹介</h1>
+            <p className="text-xl text-black/70 mb-8">
               フルスタック開発者として、技術と創造性を組み合わせたソリューションを提供しています
             </p>
           </div>
@@ -51,10 +23,10 @@ export default function About() {
           <div className="grid md:grid-cols-2 gap-12">
             {/* Personal Info */}
             <div>
-              <h2 className="text-2xl font-bold text-gray-900 mb-6">
+              <h2 className="text-2xl font-bold text-black mb-6">
                 私について
               </h2>
-              <div className="space-y-4 text-gray-600">
+              <div className="space-y-4 text-black/70">
                 <p>
                   私は情熱的なフルスタック開発者で、最新の技術トレンドに常に注目しながら、
                   ユーザー体験を重視したアプリケーションの開発に取り組んでいます。
@@ -72,12 +44,12 @@ export default function About() {
 
             {/* Skills */}
             <div>
-              <h2 className="text-2xl font-bold text-gray-900 mb-6">
+              <h2 className="text-2xl font-bold text-black mb-6">
                 技術スキル
               </h2>
               <div className="space-y-4">
                 <div>
-                  <h3 className="text-lg font-semibold text-gray-800 mb-2">
+                  <h3 className="text-lg font-semibold text-black mb-2">
                     フロントエンド
                   </h3>
                   <div className="flex flex-wrap gap-2">
@@ -98,7 +70,7 @@ export default function About() {
                   </div>
                 </div>
                 <div>
-                  <h3 className="text-lg font-semibold text-gray-800 mb-2">
+                  <h3 className="text-lg font-semibold text-black mb-2">
                     バックエンド
                   </h3>
                   <div className="flex flex-wrap gap-2">
@@ -119,7 +91,7 @@ export default function About() {
                   </div>
                 </div>
                 <div>
-                  <h3 className="text-lg font-semibold text-gray-800 mb-2">
+                  <h3 className="text-lg font-semibold text-black mb-2">
                     その他
                   </h3>
                   <div className="flex flex-wrap gap-2">
@@ -142,13 +114,13 @@ export default function About() {
       </section>
 
       {/* Experience */}
-      <section className="py-20 bg-white">
+      <section className="py-20">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
-            <h2 className="text-3xl font-bold text-gray-900 mb-4">
+            <h2 className="text-3xl font-bold text-black mb-4">
               経験と学歴
             </h2>
-            <p className="text-lg text-gray-600">
+            <p className="text-lg text-black/70">
               これまでの経験と学歴について
             </p>
           </div>
@@ -161,12 +133,12 @@ export default function About() {
                 </div>
               </div>
               <div>
-                <h3 className="text-xl font-semibold text-gray-900">
+                <h3 className="text-xl font-semibold text-black">
                   コンピュータサイエンス学士
                 </h3>
-                <p className="text-gray-600">○○大学</p>
-                <p className="text-gray-500 text-sm">2020 - 2024</p>
-                <p className="text-gray-600 mt-2">
+                <p className="text-black/70">○○大学</p>
+                <p className="text-black/60 text-sm">2020 - 2024</p>
+                <p className="text-black/70 mt-2">
                   ソフトウェアエンジニアリング、データ構造、アルゴリズム、データベースシステムなどを学びました。
                 </p>
               </div>
@@ -179,12 +151,12 @@ export default function About() {
                 </div>
               </div>
               <div>
-                <h3 className="text-xl font-semibold text-gray-900">
+                <h3 className="text-xl font-semibold text-black">
                   フルスタック開発者
                 </h3>
-                <p className="text-gray-600">○○株式会社</p>
-                <p className="text-gray-500 text-sm">2024 - 現在</p>
-                <p className="text-gray-600 mt-2">
+                <p className="text-black/70">○○株式会社</p>
+                <p className="text-black/60 text-sm">2024 - 現在</p>
+                <p className="text-black/70 mt-2">
                   React、Next.js、Node.jsを使用したWebアプリケーションの開発に従事。
                   ユーザー体験の向上とパフォーマンスの最適化に注力しています。
                 </p>
@@ -198,12 +170,12 @@ export default function About() {
                 </div>
               </div>
               <div>
-                <h3 className="text-xl font-semibold text-gray-900">
+                <h3 className="text-xl font-semibold text-black">
                   フリーランス開発者
                 </h3>
-                <p className="text-gray-600">独立</p>
-                <p className="text-gray-500 text-sm">2023 - 現在</p>
-                <p className="text-gray-600 mt-2">
+                <p className="text-black/70">独立</p>
+                <p className="text-black/60 text-sm">2023 - 現在</p>
+                <p className="text-black/70 mt-2">
                   様々なクライアントのプロジェクトに携わり、多様な技術スタックと
                   ビジネス要件に対応したソリューションを提供しています。
                 </p>
@@ -217,10 +189,10 @@ export default function About() {
       <section className="py-20">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
-            <h2 className="text-3xl font-bold text-gray-900 mb-4">
+            <h2 className="text-3xl font-bold text-black mb-4">
               興味・関心
             </h2>
-            <p className="text-lg text-gray-600">技術以外の興味や関心事</p>
+            <p className="text-lg text-black/70">技術以外の興味や関心事</p>
           </div>
 
           <div className="grid md:grid-cols-3 gap-8">
@@ -228,8 +200,8 @@ export default function About() {
               <div className="h-16 w-16 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-4">
                 <span className="text-red-600 text-2xl">📚</span>
               </div>
-              <h3 className="text-lg font-semibold text-gray-900 mb-2">読書</h3>
-              <p className="text-gray-600">
+              <h3 className="text-lg font-semibold text-black mb-2">読書</h3>
+              <p className="text-black/70">
                 技術書から小説まで、幅広いジャンルの本を読むことが好きです。
                 新しい知識を得ることと、物語に没頭することが楽しみです。
               </p>
@@ -239,8 +211,8 @@ export default function About() {
               <div className="h-16 w-16 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
                 <span className="text-blue-600 text-2xl">🎵</span>
               </div>
-              <h3 className="text-lg font-semibold text-gray-900 mb-2">音楽</h3>
-              <p className="text-gray-600">
+              <h3 className="text-lg font-semibold text-black mb-2">音楽</h3>
+              <p className="text-black/70">
                 様々なジャンルの音楽を聴くことが好きです。
                 特に、クラシック音楽とジャズを好んでいます。
               </p>
@@ -250,8 +222,8 @@ export default function About() {
               <div className="h-16 w-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
                 <span className="text-green-600 text-2xl">🏃</span>
               </div>
-              <h3 className="text-lg font-semibold text-gray-900 mb-2">運動</h3>
-              <p className="text-gray-600">
+              <h3 className="text-lg font-semibold text-black mb-2">運動</h3>
+              <p className="text-black/70">
                 ランニングとジムでのトレーニングが趣味です。
                 健康的な生活を送ることを心がけています。
               </p>

--- a/src/app/blog/[id]/page.tsx
+++ b/src/app/blog/[id]/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { blogService, BlogPost } from "@/lib/firestore";
+import SiteHeader from "@/components/SiteHeader";
 
 export default function BlogPostDetail() {
   const params = useParams();
@@ -43,7 +44,7 @@ export default function BlogPostDetail() {
     fetchPost();
   }, [params.id]);
 
-  const formatDate = (date: any) => {
+  const formatDate = (date: { toDate: () => Date } | null | undefined) => {
     if (!date) return "날짜 없음";
     try {
       return new Date(date.toDate()).toLocaleDateString("ja-JP", {
@@ -65,8 +66,8 @@ export default function BlogPostDetail() {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
-          <p className="text-gray-600">블로그 포스트를 불러오는 중...</p>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-black/70 mx-auto mb-4"></div>
+          <p className="text-black/70">블로그 포스트를 불러오는 중...</p>
         </div>
       </div>
     );
@@ -81,7 +82,7 @@ export default function BlogPostDetail() {
           </p>
           <button
             onClick={() => router.push("/blog")}
-            className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700"
+            className="bg-black text-white px-4 py-2 rounded-lg hover:bg-gray-800"
           >
             블로그 목록으로 돌아가기
           </button>
@@ -92,55 +93,24 @@ export default function BlogPostDetail() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      {/* Header */}
-      <header className="bg-white shadow-sm">
-        <nav className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between h-16">
-            <div className="flex items-center">
-              <Link href="/" className="text-xl font-bold text-gray-900">
-                ポートフォリオブログ
-              </Link>
-            </div>
-            <div className="flex items-center space-x-8">
-              <Link href="/" className="text-gray-700 hover:text-gray-900">
-                ホーム
-              </Link>
-              <Link href="/about" className="text-gray-700 hover:text-gray-900">
-                自己紹介
-              </Link>
-              <Link href="/blog" className="text-gray-700 hover:text-gray-900">
-                ブログ
-              </Link>
-              <Link href="/blog" className="text-blue-600 font-semibold">
-                ブログ
-              </Link>
-              <Link
-                href="/contact"
-                className="text-gray-700 hover:text-gray-900"
-              >
-                お問い合わせ
-              </Link>
-            </div>
-          </div>
-        </nav>
-      </header>
+      <SiteHeader />
 
       {/* Breadcrumb */}
-      <div className="bg-white border-b border-gray-200">
+      <div className="bg-gray-50 border-b border-black/10">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
           <nav className="flex" aria-label="Breadcrumb">
             <ol className="flex items-center space-x-4">
               <li>
-                <Link href="/" className="text-gray-500 hover:text-gray-700">
+                <Link href="/" className="text-black/60 hover:text-black/70">
                   ホーム
                 </Link>
               </li>
               <li>
                 <div className="flex items-center">
-                  <span className="text-gray-400 mx-2">/</span>
+                  <span className="text-black/40 mx-2">/</span>
                   <Link
                     href="/blog"
-                    className="text-gray-500 hover:text-gray-700"
+                    className="text-black/60 hover:text-black/70"
                   >
                     ブログ
                   </Link>
@@ -148,8 +118,8 @@ export default function BlogPostDetail() {
               </li>
               <li>
                 <div className="flex items-center">
-                  <span className="text-gray-400 mx-2">/</span>
-                  <span className="text-gray-900 font-medium">
+                  <span className="text-black/40 mx-2">/</span>
+                  <span className="text-black font-medium">
                     {post.title}
                   </span>
                 </div>
@@ -165,6 +135,7 @@ export default function BlogPostDetail() {
           {/* Hero Image */}
           {post.image && (
             <div className="w-full h-64 md:h-96">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 src={post.image}
                 alt={post.title}
@@ -177,24 +148,24 @@ export default function BlogPostDetail() {
             {/* Post Header */}
             <header className="mb-8">
               <div className="flex items-center space-x-4 mb-4">
-                <span className="text-sm font-medium text-blue-600 bg-blue-100 px-3 py-1 rounded-full">
+                <span className="text-sm font-medium text-black bg-gray-200 px-3 py-1 rounded-full">
                   {post.category}
                 </span>
-                <div className="flex items-center space-x-2 text-gray-500 text-sm">
+                <div className="flex items-center space-x-2 text-black/60 text-sm">
                   <span>📅</span>
                   <span>{formatDate(post.createdAt)}</span>
                 </div>
-                <div className="flex items-center space-x-2 text-gray-500 text-sm">
+                <div className="flex items-center space-x-2 text-black/60 text-sm">
                   <span>⏱️</span>
                   <span>{formatReadingTime(post.readTime)}</span>
                 </div>
               </div>
 
-              <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+              <h1 className="text-3xl md:text-4xl font-bold text-black mb-4">
                 {post.title}
               </h1>
 
-              <p className="text-xl text-gray-600 leading-relaxed">
+              <p className="text-xl text-black/70 leading-relaxed">
                 {post.excerpt}
               </p>
 
@@ -203,7 +174,7 @@ export default function BlogPostDetail() {
                 {post.tags.map((tag) => (
                   <span
                     key={tag}
-                    className="text-sm bg-gray-100 text-gray-700 px-3 py-1 rounded-full flex items-center space-x-1"
+                    className="text-sm bg-gray-100 text-black/70 px-3 py-1 rounded-full flex items-center space-x-1"
                   >
                     <span>🏷️</span>
                     <span>{tag}</span>
@@ -215,7 +186,7 @@ export default function BlogPostDetail() {
             {/* Post Content */}
             <div className="prose prose-lg max-w-none">
               <div
-                className="text-gray-800 leading-relaxed"
+                className="text-black leading-relaxed"
                 dangerouslySetInnerHTML={{
                   __html: post.content
                     .replace(
@@ -229,9 +200,9 @@ export default function BlogPostDetail() {
             </div>
 
             {/* Post Footer */}
-            <footer className="mt-12 pt-8 border-t border-gray-200">
+            <footer className="mt-12 pt-8 border-t border-black/10">
               <div className="flex items-center justify-between">
-                <div className="text-sm text-gray-500">
+                <div className="text-sm text-black/60">
                   <span>📝 작성일: {formatDate(post.createdAt)}</span>
                   {post.updatedAt && post.updatedAt !== post.createdAt && (
                     <span className="ml-4">
@@ -242,7 +213,7 @@ export default function BlogPostDetail() {
 
                 <Link
                   href="/blog"
-                  className="text-blue-600 hover:text-blue-800 font-medium flex items-center space-x-1"
+                  className="text-black underline underline-offset-2 hover:opacity-70 font-medium flex items-center space-x-1"
                 >
                   <span>←</span>
                   <span>블로그 목록으로</span>
@@ -255,7 +226,7 @@ export default function BlogPostDetail() {
         {/* Related Posts */}
         {relatedPosts.length > 0 && (
           <section className="mt-12">
-            <h2 className="text-2xl font-bold text-gray-900 mb-6">
+            <h2 className="text-2xl font-bold text-black mb-6">
               📚 관련 포스트
             </h2>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
@@ -266,6 +237,7 @@ export default function BlogPostDetail() {
                 >
                   {relatedPost.image && (
                     <div className="mb-4">
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
                       <img
                         src={relatedPost.image}
                         alt={relatedPost.title}
@@ -274,19 +246,19 @@ export default function BlogPostDetail() {
                     </div>
                   )}
                   <div className="mb-3">
-                    <span className="text-xs font-medium text-blue-600 bg-blue-100 px-2 py-1 rounded-full">
+                    <span className="text-xs font-medium text-black bg-gray-200 px-2 py-1 rounded-full">
                       {relatedPost.category}
                     </span>
                   </div>
-                  <h3 className="text-lg font-semibold text-gray-900 mb-2 line-clamp-2">
+                  <h3 className="text-lg font-semibold text-black mb-2 line-clamp-2">
                     {relatedPost.title}
                   </h3>
-                  <p className="text-gray-600 text-sm mb-4 line-clamp-3">
+                  <p className="text-black/70 text-sm mb-4 line-clamp-3">
                     {relatedPost.excerpt}
                   </p>
                   <Link
                     href={`/blog/${relatedPost.id}`}
-                    className="text-blue-600 hover:text-blue-800 text-sm font-medium"
+                    className="text-black underline underline-offset-2 hover:opacity-70 text-sm font-medium"
                   >
                     続きを読む →
                   </Link>
@@ -300,7 +272,7 @@ export default function BlogPostDetail() {
         <div className="mt-12 text-center">
           <Link
             href="/blog"
-            className="inline-flex items-center space-x-2 bg-blue-600 text-white px-6 py-3 rounded-lg font-semibold hover:bg-blue-700 transition-colors"
+            className="inline-flex items-center space-x-2 bg-black text-white px-6 py-3 rounded-lg font-semibold hover:bg-gray-800 transition-colors"
           >
             <span>←</span>
             <span>모든 블로그 포스트 보기</span>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -3,14 +3,12 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { blogService, BlogPost } from "@/lib/firestore";
-import MobileNav from "@/components/MobileNav";
-import { usePathname } from "next/navigation";
+import SiteHeader from "@/components/SiteHeader";
 
 export default function Blog() {
   const [blogPosts, setBlogPosts] = useState<BlogPost[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
-  const pathname = usePathname();
 
   useEffect(() => {
     const fetchPosts = async () => {
@@ -32,8 +30,8 @@ export default function Blog() {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
-          <p className="text-gray-600">블로그 포스트를 불러오는 중...</p>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-black/70 mx-auto mb-4"></div>
+          <p className="text-black/70">블로그 포스트를 불러오는 중...</p>
         </div>
       </div>
     );
@@ -46,7 +44,7 @@ export default function Blog() {
           <p className="text-red-600 mb-4">{error}</p>
           <button
             onClick={() => window.location.reload()}
-            className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700"
+            className="bg-black text-white px-4 py-2 rounded-lg hover:bg-gray-800"
           >
             다시 시도
           </button>
@@ -57,55 +55,16 @@ export default function Blog() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      {/* Header */}
-      <header className="bg-white shadow-sm">
-        <nav className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-16">
-            <div className="flex items-center">
-              <Link
-                href="/"
-                className="text-lg md:text-xl font-bold text-gray-900"
-              >
-                ポートフォリオブログ
-              </Link>
-            </div>
-
-            {/* 데스크톱 네비게이션 */}
-            <div className="hidden md:flex items-center space-x-8">
-              <Link href="/" className="text-gray-700 hover:text-gray-900">
-                ホーム
-              </Link>
-              <Link href="/about" className="text-gray-700 hover:text-gray-900">
-                自己紹介
-              </Link>
-              <Link href="/blog" className="text-blue-600 font-semibold">
-                ブログ
-              </Link>
-              <Link
-                href="/contact"
-                className="text-gray-700 hover:text-gray-900"
-              >
-                お問い合わせ
-              </Link>
-            </div>
-
-            {/* 모바일 네비게이션 */}
-            <MobileNav
-              siteTitle="ポートフォリオブログ"
-              currentPath={pathname}
-            />
-          </div>
-        </nav>
-      </header>
+      <SiteHeader />
 
       {/* Hero Section */}
-      <section className="bg-white py-12 md:py-20">
+      <section className="py-12 md:py-20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center">
-            <h1 className="text-2xl md:text-4xl font-bold text-gray-900 mb-4 md:mb-6">
+            <h1 className="text-2xl md:text-4xl font-bold text-black mb-4 md:mb-6">
               ブログ
             </h1>
-            <p className="text-lg md:text-xl text-gray-600 mb-6 md:mb-8 px-4">
+            <p className="text-lg md:text-xl text-black/70 mb-6 md:mb-8 px-4">
               技術的な学びや経験を共有するブログ記事
             </p>
           </div>
@@ -116,7 +75,7 @@ export default function Blog() {
       <section className="py-12 md:py-20">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="space-y-6 md:space-y-8">
-            {blogPosts.map((post, index) => (
+            {blogPosts.map((post) => (
               <article
                 key={post.id}
                 className="bg-white rounded-lg shadow-sm p-4 md:p-8 hover:shadow-md transition-shadow blog-card"
@@ -124,6 +83,7 @@ export default function Blog() {
                 {/* Blog Image */}
                 {post.image && (
                   <div className="mb-4 md:mb-6">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
                       src={post.image}
                       alt={post.title}
@@ -132,10 +92,10 @@ export default function Blog() {
                   </div>
                 )}
                 <div className="flex flex-wrap items-center gap-2 md:gap-4 mb-3 md:mb-4">
-                  <span className="text-xs md:text-sm font-medium text-blue-600 bg-blue-100 px-2 md:px-3 py-1 rounded-full">
+                  <span className="text-xs md:text-sm font-medium text-black bg-gray-200 px-2 md:px-3 py-1 rounded-full">
                     {post.category}
                   </span>
-                  <div className="flex items-center space-x-1 md:space-x-2 text-gray-500 text-xs md:text-sm">
+                  <div className="flex items-center space-x-1 md:space-x-2 text-black/60 text-xs md:text-sm">
                     <span>📅</span>
                     <span>
                       {post.createdAt
@@ -145,17 +105,17 @@ export default function Blog() {
                         : "날짜 없음"}
                     </span>
                   </div>
-                  <div className="flex items-center space-x-1 md:space-x-2 text-gray-500 text-xs md:text-sm">
+                  <div className="flex items-center space-x-1 md:space-x-2 text-black/60 text-xs md:text-sm">
                     <span>⏱️</span>
                     <span>{post.readTime}</span>
                   </div>
                 </div>
 
-                <h2 className="text-lg md:text-2xl font-bold text-gray-900 mb-3 md:mb-4">
+                <h2 className="text-lg md:text-2xl font-bold text-black mb-3 md:mb-4">
                   {post.title}
                 </h2>
 
-                <p className="text-sm md:text-base text-gray-600 mb-4 md:mb-6">
+                <p className="text-sm md:text-base text-black/70 mb-4 md:mb-6">
                   {post.excerpt}
                 </p>
 
@@ -164,7 +124,7 @@ export default function Blog() {
                     {post.tags.map((tag) => (
                       <span
                         key={tag}
-                        className="text-xs bg-gray-100 text-gray-700 px-2 py-1 rounded flex items-center space-x-1"
+                        className="text-xs bg-gray-100 text-black/70 px-2 py-1 rounded flex items-center space-x-1"
                       >
                         <span>🏷️</span>
                         <span>{tag}</span>
@@ -174,7 +134,7 @@ export default function Blog() {
 
                   <Link
                     href={`/blog/${post.id}`}
-                    className="text-blue-600 hover:text-blue-800 font-medium hover:underline transition-colors text-sm md:text-base"
+                    className="text-black underline underline-offset-2 hover:opacity-70 font-medium text-sm md:text-base"
                   >
                     続きを読む →
                   </Link>
@@ -186,22 +146,22 @@ export default function Blog() {
       </section>
 
       {/* Newsletter */}
-      <section className="py-12 md:py-20 bg-white">
+      <section className="py-12 md:py-20">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <div>
-            <h2 className="text-2xl md:text-3xl font-bold text-gray-900 mb-3 md:mb-4">
+            <h2 className="text-2xl md:text-3xl font-bold text-black mb-3 md:mb-4">
               最新の記事を受け取る
             </h2>
-            <p className="text-base md:text-lg text-gray-600 mb-6 md:mb-8 px-4">
+            <p className="text-base md:text-lg text-black/70 mb-6 md:mb-8 px-4">
               新しい記事が公開されたら、メールでお知らせします
             </p>
             <div className="flex flex-col sm:flex-row gap-3 md:gap-4 justify-center max-w-md mx-auto px-4">
               <input
                 type="email"
                 placeholder="メールアドレスを入力"
-                className="flex-1 px-3 md:px-4 py-2 md:py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm md:text-base"
+                className="flex-1 px-3 md:px-4 py-2 md:py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-black focus:border-transparent text-sm md:text-base"
               />
-              <button className="bg-blue-600 text-white px-4 md:px-6 py-2 md:py-3 rounded-lg font-semibold hover:bg-blue-700 transition-colors text-sm md:text-base">
+              <button className="bg-black text-white px-4 md:px-6 py-2 md:py-3 rounded-lg font-semibold hover:bg-gray-800 transition-colors text-sm md:text-base">
                 購読する
               </button>
             </div>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import Link from "next/link";
 import { useState } from "react";
 import { contactService } from "@/lib/firestore";
+import SiteHeader from "@/components/SiteHeader";
 
 export default function Contact() {
   const [formData, setFormData] = useState({
@@ -47,41 +47,16 @@ export default function Contact() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      {/* Header */}
-      <header className="bg-white shadow-sm">
-        <nav className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between h-16">
-            <div className="flex items-center">
-              <Link href="/" className="text-xl font-bold text-gray-900">
-                ポートフォリオブログ
-              </Link>
-            </div>
-            <div className="flex items-center space-x-8">
-              <Link href="/" className="text-gray-700 hover:text-gray-900">
-                ホーム
-              </Link>
-              <Link href="/about" className="text-gray-700 hover:text-gray-900">
-                自己紹介
-              </Link>
-              <Link href="/blog" className="text-gray-700 hover:text-gray-900">
-                ブログ
-              </Link>
-              <Link href="/contact" className="text-blue-600 font-semibold">
-                お問い合わせ
-              </Link>
-            </div>
-          </div>
-        </nav>
-      </header>
+      <SiteHeader />
 
       {/* Hero Section */}
-      <section className="bg-white py-20">
+      <section className="py-20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center">
-            <h1 className="text-4xl font-bold text-gray-900 mb-6">
+            <h1 className="text-4xl font-bold text-black mb-6">
               お問い合わせ
             </h1>
-            <p className="text-xl text-gray-600 mb-8">
+            <p className="text-xl text-black/70 mb-8">
               新しい機会やプロジェクトについてお話ししましょう
             </p>
           </div>
@@ -94,7 +69,7 @@ export default function Contact() {
           <div className="grid lg:grid-cols-2 gap-12">
             {/* Contact Form */}
             <div>
-              <h2 className="text-2xl font-bold text-gray-900 mb-6">
+              <h2 className="text-2xl font-bold text-black mb-6">
                 メッセージを送る
               </h2>
 
@@ -115,7 +90,7 @@ export default function Contact() {
                 <div>
                   <label
                     htmlFor="name"
-                    className="block text-sm font-medium text-gray-700 mb-2"
+                    className="block text-sm font-medium text-black/70 mb-2"
                   >
                     お名前
                   </label>
@@ -126,7 +101,7 @@ export default function Contact() {
                     value={formData.name}
                     onChange={handleInputChange}
                     required
-                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-black focus:border-transparent"
                     placeholder="山田太郎"
                   />
                 </div>
@@ -134,7 +109,7 @@ export default function Contact() {
                 <div>
                   <label
                     htmlFor="email"
-                    className="block text-sm font-medium text-gray-700 mb-2"
+                    className="block text-sm font-medium text-black/70 mb-2"
                   >
                     メールアドレス
                   </label>
@@ -145,7 +120,7 @@ export default function Contact() {
                     value={formData.email}
                     onChange={handleInputChange}
                     required
-                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-black focus:border-transparent"
                     placeholder="example@email.com"
                   />
                 </div>
@@ -153,7 +128,7 @@ export default function Contact() {
                 <div>
                   <label
                     htmlFor="subject"
-                    className="block text-sm font-medium text-gray-700 mb-2"
+                    className="block text-sm font-medium text-black/70 mb-2"
                   >
                     件名
                   </label>
@@ -164,7 +139,7 @@ export default function Contact() {
                     value={formData.subject}
                     onChange={handleInputChange}
                     required
-                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-black focus:border-transparent"
                     placeholder="プロジェクトについて"
                   />
                 </div>
@@ -172,7 +147,7 @@ export default function Contact() {
                 <div>
                   <label
                     htmlFor="message"
-                    className="block text-sm font-medium text-gray-700 mb-2"
+                    className="block text-sm font-medium text-black/70 mb-2"
                   >
                     メッセージ
                   </label>
@@ -183,7 +158,7 @@ export default function Contact() {
                     onChange={handleInputChange}
                     required
                     rows={6}
-                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-black focus:border-transparent"
                     placeholder="メッセージを入力してください..."
                   ></textarea>
                 </div>
@@ -191,7 +166,7 @@ export default function Contact() {
                 <button
                   type="submit"
                   disabled={isSubmitting}
-                  className="w-full bg-blue-600 text-white py-3 px-6 rounded-lg font-semibold hover:bg-blue-700 transition-colors disabled:bg-gray-400 disabled:cursor-not-allowed"
+                  className="w-full bg-black text-white py-3 px-6 rounded-lg font-semibold hover:bg-gray-800 transition-colors disabled:bg-gray-400 disabled:cursor-not-allowed"
                 >
                   {isSubmitting ? "送信中..." : "メッセージを送る"}
                 </button>
@@ -200,22 +175,22 @@ export default function Contact() {
 
             {/* Contact Information */}
             <div>
-              <h2 className="text-2xl font-bold text-gray-900 mb-6">
+              <h2 className="text-2xl font-bold text-black mb-6">
                 連絡先情報
               </h2>
               <div className="space-y-6">
                 <div className="flex items-start space-x-4">
                   <div className="flex-shrink-0">
-                    <div className="h-12 w-12 bg-blue-100 rounded-full flex items-center justify-center">
-                      <span className="text-blue-600 text-xl">📧</span>
+                    <div className="h-12 w-12 bg-gray-200 rounded-full flex items-center justify-center">
+                      <span className="text-black text-xl">📧</span>
                     </div>
                   </div>
                   <div>
-                    <h3 className="text-lg font-semibold text-gray-900">
+                    <h3 className="text-lg font-semibold text-black">
                       メール
                     </h3>
-                    <p className="text-gray-600">choi.su000330@gmail.com</p>
-                    <p className="text-gray-500 text-sm">
+                    <p className="text-black/70">choi.su000330@gmail.com</p>
+                    <p className="text-black/60 text-sm">
                       通常24時間以内に返信いたします
                     </p>
                   </div>
@@ -223,16 +198,16 @@ export default function Contact() {
 
                 <div className="flex items-start space-x-4">
                   <div className="flex-shrink-0">
-                    <div className="h-12 w-12 bg-green-100 rounded-full flex items-center justify-center">
-                      <span className="text-green-600 text-xl">📱</span>
+                    <div className="h-12 w-12 bg-gray-200 rounded-full flex items-center justify-center">
+                      <span className="text-black text-xl">📱</span>
                     </div>
                   </div>
                   <div>
-                    <h3 className="text-lg font-semibold text-gray-900">
+                    <h3 className="text-lg font-semibold text-black">
                       電話
                     </h3>
-                    <p className="text-gray-600">+82-10-1234-5678</p>
-                    <p className="text-gray-500 text-sm">
+                    <p className="text-black/70">+82-10-1234-5678</p>
+                    <p className="text-black/60 text-sm">
                       平日 9:00-18:00 (KST)
                     </p>
                   </div>
@@ -240,31 +215,31 @@ export default function Contact() {
 
                 <div className="flex items-start space-x-4">
                   <div className="flex-shrink-0">
-                    <div className="h-12 w-12 bg-purple-100 rounded-full flex items-center justify-center">
-                      <span className="text-purple-600 text-xl">📍</span>
+                    <div className="h-12 w-12 bg-gray-200 rounded-full flex items-center justify-center">
+                      <span className="text-black text-xl">📍</span>
                     </div>
                   </div>
                   <div>
-                    <h3 className="text-lg font-semibold text-gray-900">
+                    <h3 className="text-lg font-semibold text-black">
                       所在地
                     </h3>
-                    <p className="text-gray-600">
+                    <p className="text-black/70">
                       ソウル特別市江南区
                       <br />
                       大韓民国
                     </p>
-                    <p className="text-gray-500 text-sm">リモートワーク可能</p>
+                    <p className="text-black/60 text-sm">リモートワーク可能</p>
                   </div>
                 </div>
 
                 <div className="flex items-start space-x-4">
                   <div className="flex-shrink-0">
-                    <div className="h-12 w-12 bg-orange-100 rounded-full flex items-center justify-center">
-                      <span className="text-orange-600 text-xl">🌐</span>
+                    <div className="h-12 w-12 bg-gray-200 rounded-full flex items-center justify-center">
+                      <span className="text-black text-xl">🌐</span>
                     </div>
                   </div>
                   <div>
-                    <h3 className="text-lg font-semibold text-gray-900">
+                    <h3 className="text-lg font-semibold text-black">
                       ソーシャルメディア
                     </h3>
                     <div className="space-y-2">
@@ -272,7 +247,7 @@ export default function Contact() {
                         href="https://github.com/username"
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="block text-blue-600 hover:text-blue-800"
+                        className="block text-black underline hover:opacity-70"
                       >
                         GitHub
                       </a>
@@ -280,7 +255,7 @@ export default function Contact() {
                         href="https://linkedin.com/in/username"
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="block text-blue-600 hover:text-blue-800"
+                        className="block text-black underline hover:opacity-70"
                       >
                         LinkedIn
                       </a>
@@ -288,7 +263,7 @@ export default function Contact() {
                         href="https://twitter.com/username"
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="block text-blue-600 hover:text-blue-800"
+                        className="block text-black underline hover:opacity-70"
                       >
                         Twitter
                       </a>
@@ -302,41 +277,41 @@ export default function Contact() {
       </section>
 
       {/* FAQ Section */}
-      <section className="py-20 bg-white">
+      <section className="py-20">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
-            <h2 className="text-3xl font-bold text-gray-900 mb-4">
+            <h2 className="text-3xl font-bold text-black mb-4">
               よくある質問
             </h2>
-            <p className="text-lg text-gray-600">よくいただく質問と回答</p>
+            <p className="text-lg text-black/70">よくいただく質問と回答</p>
           </div>
 
           <div className="space-y-8">
             <div className="bg-gray-50 rounded-lg p-6">
-              <h3 className="text-lg font-semibold text-gray-900 mb-2">
+              <h3 className="text-lg font-semibold text-black mb-2">
                 プロジェクトの依頼はどのような形式で受け付けていますか？
               </h3>
-              <p className="text-gray-600">
+              <p className="text-black/70">
                 フリーランスとして、リモートワークでのプロジェクトを主に受け付けています。
                 お気軽にメールでご相談ください。
               </p>
             </div>
 
             <div className="bg-gray-50 rounded-lg p-6">
-              <h3 className="text-lg font-semibold text-gray-900 mb-2">
+              <h3 className="text-lg font-semibold text-black mb-2">
                 技術的な相談にも対応していますか？
               </h3>
-              <p className="text-gray-600">
+              <p className="text-black/70">
                 はい、技術的な相談やアドバイスも喜んでお受けします。特にReact、
                 Next.js、Node.jsに関する相談を多く受けています。
               </p>
             </div>
 
             <div className="bg-gray-50 rounded-lg p-6">
-              <h3 className="text-lg font-semibold text-gray-900 mb-2">
+              <h3 className="text-lg font-semibold text-black mb-2">
                 料金体系について教えてください
               </h3>
-              <p className="text-gray-600">
+              <p className="text-black/70">
                 プロジェクトの規模や内容によって料金は変動します。詳細については、
                 お問い合わせいただいた際にご相談させていただきます。
               </p>

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import MobileNav from "@/components/MobileNav";
+
+export default function SiteHeader() {
+  const pathname = usePathname();
+  const links = [
+    { label: "ホーム", href: "/" },
+    { label: "自己紹介", href: "/about" },
+    { label: "ブログ", href: "/blog" },
+    { label: "お問い合わせ", href: "/contact" },
+  ];
+
+  return (
+    <header className="sticky top-0 left-0 right-0 z-40 bg-gray-50 border-b border-black/10">
+      <nav className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between h-16">
+          <div className="flex items-center gap-6">
+            <Link
+              href="https://github.com/username"
+              target="_blank"
+              rel="noreferrer"
+              className="underline underline-offset-[6px] decoration-1 hover:opacity-70 transition text-sm md:text-base"
+            >
+              GitHub
+            </Link>
+            <Link
+              href="https://velog.io/@username"
+              target="_blank"
+              rel="noreferrer"
+              className="underline underline-offset-[6px] decoration-1 hover:opacity-70 transition text-sm md:text-base"
+            >
+              Velog
+            </Link>
+          </div>
+          <div className="hidden md:flex items-center space-x-8">
+            {links.map((n) => (
+              <Link
+                key={n.href}
+                href={n.href}
+                className={`transition-colors border-b-2 pb-1 $
+                  {pathname === n.href
+                    ? "text-black font-semibold border-black"
+                    : "text-black/80 hover:text-black border-transparent hover:border-black/60"}
+                `}
+              >
+                {n.label}
+              </Link>
+            ))}
+          </div>
+          <div className="md:hidden">
+            <MobileNav siteTitle="ポートフォリオブログ" currentPath={pathname} />
+          </div>
+        </div>
+      </nav>
+    </header>
+  );
+}
+


### PR DESCRIPTION
## Summary
- restyle blog, post, and contact buttons with black/gray/white palette
- align blog badges and links with the main screen’s monochrome design
- tidy newsletter and contact forms with matching focus rings and link styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and no-img-element errors in untouched files)*

------
https://chatgpt.com/codex/tasks/task_b_68987138e3848332ba1c335a6fa5ec1b